### PR TITLE
chore: update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/KeitaShimura/logs-collector-client
 go 1.24.5
 
 require (
-	github.com/KeitaShimura/logs-collector-protos/go v0.0.2
+	github.com/KeitaShimura/logs-collector-protos/go v0.0.3
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/KeitaShimura/logs-collector-protos/go v0.0.2 h1:noU+MGhiyCpBHpBmvfSgjcBLteICxdZFXk2wrwkquR8=
-github.com/KeitaShimura/logs-collector-protos/go v0.0.2/go.mod h1:CipOUY/ZJ9RBu2RZ/zzvPOCRSCBQPJib7MTQwHCvEys=
+github.com/KeitaShimura/logs-collector-protos/go v0.0.3 h1:tq0hjfAKlQw4n8+ed0OcsDnZmmL+ahkuXpDwpqqo/Jk=
+github.com/KeitaShimura/logs-collector-protos/go v0.0.3/go.mod h1:rl94FrGxY2ZgaC3xmcBlelAVsVeH6PUJiw3Q4U+k+RY=
 github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5mCA=
 github.com/caarlos0/env/v11 v11.3.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## 概要

- `github.com/KeitaShimura/logs-collector-protos/go` のバージョンを `v0.0.2` から `v0.0.3` に更新し、`go get -u ./...` および `go mod tidy` を用いて依存関係の最適化を行いました。